### PR TITLE
Create initial models without initial or partial initial observation

### DIFF
--- a/engine/engine.py
+++ b/engine/engine.py
@@ -66,9 +66,11 @@ class Engine:
             print('in Model.run(): InconsistencyChecker claims scenario and/or domain description is invalid')
             return False
         # Create initial model which corresponds to the initial state
-        initial_model = Model(self.checker.valid_scenario)
+        fluents = self.get_all_fluents(self.checker.domain_desc)
+        initial_condition = self.create_initial_condition(self.checker.valid_scenario, fluents)
+        initial_model = Model(self.checker.valid_scenario, fluents, initial_condition)
         # We may have more than 1 initial model
-        self.models += self.fork_model(initial_model, self.checker.sorted_observations[0].condition.formula, 0, 0)
+        self.models += self.fork_model(initial_model, initial_condition, 0, 0)
         self.models = self.checker.remove_duplicate_models(self.models)
         # i = 0
         # for m in self.models:

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -169,3 +169,18 @@ class Engine:
                 if statement.condition.formula is not True:
                     fluents = list(set(fluents) | set(statement.condition.formula.atoms()))
         return fluents
+
+    def create_initial_condition(self, scenario: Scenario, fluents: List[Symbol]):
+        initial_statement = BooleanFalse
+        if len(scenario.observations) != 0 and scenario.observations[0].begin_time == 0:
+            initial_statement = scenario.observations[0].condition.formula
+            not_used_fluents = list(set(fluents) - set(scenario.observations[0].condition.formula.atoms()))
+            for fluent in not_used_fluents:
+                initial_statement = Or(initial_statement, Or(fluent, Not(fluent)))
+        else:
+            for fluent in fluents:
+                if initial_statement is BooleanFalse:
+                    initial_statement = Or(fluent, Not(fluent))
+                else:
+                    initial_statement = Or(initial_statement, Or(fluent, Not(fluent)))
+        return initial_statement

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1,7 +1,9 @@
 from engine.inconsistency_checker import InconsistencyChecker
 from engine.model import Model
 from sympy.logic import boolalg
-from structs.statements import Causes, Releases, Statement, EffectStatement, Triggers
+from sympy.core.symbol import Symbol
+from sympy.logic.boolalg import BooleanFalse, Or, Not
+from structs.statements import Causes, Releases, Statement, EffectStatement, Triggers, ImpossibleIf
 from structs.action_occurrence import ActionOccurrence
 from typing import List, Dict, Optional
 from copy import deepcopy
@@ -155,3 +157,15 @@ class Engine:
                     if evaluation:
                         # model.triggered_actions = {time: ActionOccurrence(statement.action, time, statement.agent, 1)}
                         model.triggered_actions = {time: ActionOccurrence(statement.action, time, 'nobody', 1)}
+
+    def get_all_fluents(self, domain_description: DomainDescription):
+        fluents = []
+        for statement in domain_description.statements:
+            if isinstance(statement, EffectStatement):
+                fluents = list(set(fluents) | set(statement.effect.formula.atoms()))
+                if statement.condition is not True:
+                    fluents = list(set(fluents) | set(statement.condition.formula.atoms()))
+            if isinstance(statement, Triggers) or isinstance(statement, ImpossibleIf):
+                if statement.condition.formula is not True:
+                    fluents = list(set(fluents) | set(statement.condition.formula.atoms()))
+        return fluents

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -91,6 +91,7 @@ class Engine:
             self.checker.remove_bad_observations(self.models, t)
             # Remove duplicates
             self.models = self.checker.remove_duplicate_models(self.models)
+
             print('At time', t, 'we have', len(self.models), 'models')
 
         return True
@@ -103,7 +104,7 @@ class Engine:
         :param model: The model to be forked, it could be removed from the list of models if
         :param formula: The sympy boolean formula that must hold at this time
         :param time: The time at which the action effect given by "formula" must hold in the model
-        :param duration: The duration of action is used for occusion regions
+        :param duration: The duration of action is used for occlusion regions
         :param is_releases_statement: If true, then we keep the model that we want to fork. 
         If false, it means we want to fork based on a CAUSES statement,
         so we remove the model that was passed in because we only want to have models where formula MUST HOLD

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -143,7 +143,7 @@ class Engine:
 
         return new_models
 
-    def handle_trigger_statements(self, time: int, scenario: Scenario):
+    def handle_trigger_statements(self, time: int):
         for model in self.models:
             expr, expr_values = model.get_symbol_values(time)
             expr_pre, expr_values_pre = model.get_symbol_values(time-1);

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -93,7 +93,7 @@ class Engine:
             self.checker.remove_bad_observations(self.models, t)
             # Remove duplicates
             self.models = self.checker.remove_duplicate_models(self.models)
-            self.handle_trigger_statements(time=t)
+            self.handle_trigger_statements(time=t, scenario=Scenario)
             print('At time', t, 'we have', len(self.models), 'models')
 
         return True
@@ -143,11 +143,12 @@ class Engine:
 
         return new_models
 
-    def handle_trigger_statements(self, time: int):
+    def handle_trigger_statements(self, time: int, scenario: Scenario):
         for model in self.models:
             expr, expr_values = model.get_symbol_values(time)
+            expr_pre, expr_values_pre = model.get_symbol_values(time-1);
             for statement in self.checker.domain_desc.statements:
                 if isinstance(statement, Triggers):
-                    evaluation = self.checker.evaluate(expr, expr_values, statement.condition.formula)
+                    evaluation = self.checker.evaluate_trigger(expr_pre, expr_values_pre, expr, expr_values, statement.condition.formula)
                     if evaluation:
-                        model.triggered_actions = {time: ActionOccurrence(statement.action, time, 'nobody', 1)}
+                        model.triggered_actions = {time: ActionOccurrence(statement.action, time, statement.agent, 1)}

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -93,7 +93,7 @@ class Engine:
             self.checker.remove_bad_observations(self.models, t)
             # Remove duplicates
             self.models = self.checker.remove_duplicate_models(self.models)
-            self.handle_trigger_statements(time=t, scenario=Scenario)
+            self.handle_trigger_statements(time=t)
             print('At time', t, 'we have', len(self.models), 'models')
 
         return True
@@ -116,9 +116,10 @@ class Engine:
         solutions = satisfiable(formula, all_models=True)
 
         for s in solutions:
-            new_model = deepcopy(model)
-            new_model.update_fluent_history(s, time, duration)
-            new_models.append(new_model)
+            if s is not False:
+                new_model = deepcopy(model)
+                new_model.update_fluent_history(s, time, duration)
+                new_models.append(new_model)
 
         if model in self.models:
             self.models.remove(model)
@@ -143,7 +144,7 @@ class Engine:
 
         return new_models
 
-    def handle_trigger_statements(self, time: int, scenario: Scenario):
+    def handle_trigger_statements(self, time: int):
         for model in self.models:
             expr, expr_values = model.get_symbol_values(time)
             # expr_pre, expr_values_pre = model.get_symbol_values(time-1)

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -143,12 +143,14 @@ class Engine:
 
         return new_models
 
-    def handle_trigger_statements(self, time: int):
+    def handle_trigger_statements(self, time: int, scenario: Scenario):
         for model in self.models:
             expr, expr_values = model.get_symbol_values(time)
-            expr_pre, expr_values_pre = model.get_symbol_values(time-1);
+            # expr_pre, expr_values_pre = model.get_symbol_values(time-1)
             for statement in self.checker.domain_desc.statements:
                 if isinstance(statement, Triggers):
-                    evaluation = self.checker.evaluate_trigger(expr_pre, expr_values_pre, expr, expr_values, statement.condition.formula)
+                    # evaluation = self.checker.evaluate_trigger(expr_pre, expr_values_pre, expr, expr_values, statement.condition.formula)
+                    evaluation = self.checker.evaluate(expr, expr_values, statement.condition.formula)
                     if evaluation:
-                        model.triggered_actions = {time: ActionOccurrence(statement.action, time, statement.agent, 1)}
+                        # model.triggered_actions = {time: ActionOccurrence(statement.action, time, statement.agent, 1)}
+                        model.triggered_actions = {time: ActionOccurrence(statement.action, time, 'nobody', 1)}

--- a/engine/inconsistency_checker.py
+++ b/engine/inconsistency_checker.py
@@ -199,7 +199,7 @@ class InconsistencyChecker:
                 if statement.action == action.name and action.begin_time + statement.duration == time:
                     evaluation = None
                     current_action = action
-                    if statement.duration <= action.duration: # Use only statements which duration can be filled in the action occurence
+                    if statement.duration <= action.duration:  # Use only statements which duration can be filled in the action occurence
                         if expr is None or expr_values is None:
                             # We found an ActionOccurrence, let's get the symbol values in the model at the time it occurred
                             # So we can evaluate action preconditions against them
@@ -220,8 +220,9 @@ class InconsistencyChecker:
                                 # Load releases ~hidden in 2
                                 # Load releases loaded in 2
                                 # Both statements are joined into 1 larger one: Load releases ~hidden & loaded in 2
-                                current_statements['releases'] = self.join_statement_by_and(current_statements['releases'],
-                                                                                            statement, False)
+                                current_statements['releases'] = self.join_statement_by_and(
+                                    current_statements['releases'],
+                                    statement, False)
                         # The same happens to causes statements...
                         elif evaluation and isinstance(statement, Causes):
                             if current_statements['causes'] is None:

--- a/engine/inconsistency_checker.py
+++ b/engine/inconsistency_checker.py
@@ -351,6 +351,27 @@ class InconsistencyChecker:
         return eval
 
     @staticmethod
+    def evaluate_trigger(symbols_pre: List[Symbol], symbol_values_pre: List[bool], symbols: List[Symbol], symbol_values: List[bool], formula: boolalg.Boolean) -> bool:
+
+        t = 0
+        f = lambdify(symbols_pre, formula, modules={'And': any, 'Or': all})
+        combinations = InconsistencyChecker.get_all_combinations(symbol_values_pre)
+        eval = f(*combinations[0])
+        for i in range(1, len(combinations)):
+            if f(*combinations[i]) != eval:
+                return None;
+        if not eval:
+            f = lambdify(symbols, formula, modules={'And': any, 'Or': all})
+            combinations = InconsistencyChecker.get_all_combinations(symbol_values)
+            eval = f(*combinations[0])
+            for i in range(1, len(combinations)):
+                if f(*combinations[i]) != eval:
+                    return None
+            return eval
+        else:
+            return False
+
+    @staticmethod
     def get_all_combinations(symbol_values: List[bool]) -> List[List[bool]]:
         combinations = []
         combinations.append(symbol_values)

--- a/engine/inconsistency_checker.py
+++ b/engine/inconsistency_checker.py
@@ -81,16 +81,21 @@ class InconsistencyChecker:
                 else:
                     for j in range(len(self.joined_statements[statement.action])):
                         if self.joined_statements[statement.action][j].duration == statement.duration and \
-                                self.joined_statements[statement.action][j].condition == statement.condition and \
-                                self.joined_statements[statement.action][j].agent == statement.agent:
+                                self.joined_statements[statement.action][j].condition == statement.condition:
                             if isinstance(statement, Causes) and isinstance(self.joined_statements[statement.action][j],
                                                                             Causes):
-                                self.joined_statements[statement.action][j] = self.join_statement_by_and(
-                                    self.joined_statements[statement.action][j], statement, True)
+                                if self.joined_statements[statement.action][j].agent == statement.agent:
+                                    self.joined_statements[statement.action][j] = self.join_statement_by_and(
+                                        self.joined_statements[statement.action][j], statement, True)
+                                else:
+                                    self.joined_statements[statement.action].append(statement)
                             elif isinstance(statement, Releases) and isinstance(
                                     self.joined_statements[statement.action][j], Releases):
-                                self.joined_statements[statement.action][j] = self.create_tautology_from_statements(
-                                    self.joined_statements[statement.action][j], statement)
+                                if self.joined_statements[statement.action][j].agent == statement.agent:
+                                    self.joined_statements[statement.action][j] = self.create_tautology_from_statements(
+                                        self.joined_statements[statement.action][j], statement)
+                                else:
+                                    self.joined_statements[statement.action].append(statement)
                         else:
                             self.joined_statements[statement.action].append(statement)
 
@@ -366,11 +371,11 @@ class InconsistencyChecker:
         if is_causes:
             return Causes(action=statement1.action,
                           effect=Condition(And(statement1.effect.formula, statement2.effect.formula)),
-                          duration=statement1.duration)
+                          duration=statement1.duration, agent=statement1.agent)
         else:
             return Releases(action=statement1.action,
                             effect=Condition(And(statement1.effect.formula, statement2.effect.formula)),
-                            duration=statement1.duration)
+                            duration=statement1.duration, agent=statement1.agent)
 
     """
     Returns a Releases statement that will have a formula that holds for all input (tautology)
@@ -381,7 +386,7 @@ class InconsistencyChecker:
     def create_tautology_from_statements(self, statement1: Statement, statement2: Statement) -> Statement:
         return Releases(action=statement1.action,
                         effect=Condition(Or(statement1.effect.formula, Not(statement2.effect.formula))),
-                        duration=statement1.duration)
+                        duration=statement1.duration, agent=statement1.agent)
 
     def action_impossible_at(self, action: ActionOccurrence) -> bool:
         """

--- a/engine/model.py
+++ b/engine/model.py
@@ -21,6 +21,7 @@ class Model:
         self.last_time_point = last_action.begin_time + last_action.duration + 1
         self.fluent_history = self.initialize_history(scenario)
         self.action_history = dict()
+        self.triggered_actions = None  # time: int -> statement
 
     def initialize_history(self, scenario: Scenario) -> ndarray:
         fluent_history = ndarray(shape=(self.last_time_point, len(self.fluents)), dtype=Fluent)

--- a/engine/preprocessor.py
+++ b/engine/preprocessor.py
@@ -25,24 +25,24 @@ class Preprocessor:
         if isinstance(statement, EffectStatement):
             for j in range(len(unique_stat)):
                 if (isinstance(unique_stat[j], EffectStatement)
-                and (statement.action == unique_stat[j].action)
-                and (statement.duration == unique_stat[j].duration)
-                and (statement.condition == unique_stat[j].condition)
-                and (statement.effect == unique_stat[j].effect)):
+                        and (statement.action == unique_stat[j].action)
+                        and (statement.duration == unique_stat[j].duration)
+                        and (statement.condition == unique_stat[j].condition)
+                        and (statement.effect == unique_stat[j].effect)):
                     return False
 
         if isinstance(statement, ImpossibleIf):
             for j in range(len(unique_stat)):
                 if (isinstance(unique_stat[j], ImpossibleIf)
-                and (statement.action == unique_stat[j].action)
-                and (statement.condition == unique_stat[j].condition)):
+                        and (statement.action == unique_stat[j].action)
+                        and (statement.condition == unique_stat[j].condition)):
                     return False
 
         if isinstance(statement, ImpossibleAt):
             for j in range(len(unique_stat)):
                 if (isinstance(unique_stat[j], ImpossibleAt)
-                and (statement.action == unique_stat[j].action)
-                and (statement.time == unique_stat[j].time)):
+                        and (statement.action == unique_stat[j].action)
+                        and (statement.time == unique_stat[j].time)):
                     return False
         return True
 
@@ -52,7 +52,7 @@ class Preprocessor:
             unique = True
             for j in range(len(unique_obs)):
                 if ((observations[i].condition == unique_obs[j].condition)
-                and (observations[i].begin_time == unique_obs[j].begin_time)):
+                        and (observations[i].begin_time == unique_obs[j].begin_time)):
                     unique = False
                     break
             if unique:
@@ -65,8 +65,8 @@ class Preprocessor:
             unique = True
             for j in range(len(unique_act)):
                 if ((actions[i].duration == unique_act[j].duration)
-                and (actions[i].begin_time == unique_act[j].begin_time)
-                and (actions[i].name == unique_act[j].name)):
+                        and (actions[i].begin_time == unique_act[j].begin_time)
+                        and (actions[i].name == unique_act[j].name)):
                     unique = False
                     break
             if unique:

--- a/example/Example3a/lib.adl3
+++ b/example/Example3a/lib.adl3
@@ -1,0 +1,3 @@
+A causes f by Tom
+B causes g by Jim
+impossible B by Tom

--- a/example/Example3a/queries.txt
+++ b/example/Example3a/queries.txt
@@ -1,0 +1,6 @@
+possibly involved Jim
+necessary involved Jim
+possibly f at 2 when ExampleScenario
+necessary f at 2 when ExampleScenario
+possibly A at 1
+necessary A at 1

--- a/example/Example3a/scenario.txt
+++ b/example/Example3a/scenario.txt
@@ -1,0 +1,3 @@
+OBS:
+ACS:
+A Jim 1

--- a/example/Example3b/lib.adl3
+++ b/example/Example3b/lib.adl3
@@ -1,0 +1,3 @@
+A causes f by Tom
+B causes g by Jim
+impossible B by Tom

--- a/example/Example3b/queries.txt
+++ b/example/Example3b/queries.txt
@@ -1,0 +1,6 @@
+possibly involved Tom
+necessary involved Tom
+possibly f at 1
+necessary f at 1
+possibly B at 0
+necessary B at 0

--- a/example/Example3b/scenario.txt
+++ b/example/Example3b/scenario.txt
@@ -1,0 +1,3 @@
+OBS:
+ACS:
+B Tom 0

--- a/example/Example4a/lib.adl3
+++ b/example/Example4a/lib.adl3
@@ -1,0 +1,2 @@
+A causes f if g by Tom
+A causes ~f if p by Tom

--- a/example/Example4a/queries.txt
+++ b/example/Example4a/queries.txt
@@ -1,0 +1,4 @@
+possibly involved Tom
+necessary involved Tom
+possibly A at 0
+necessary A at 0

--- a/example/Example4a/scenario.txt
+++ b/example/Example4a/scenario.txt
@@ -1,0 +1,4 @@
+OBS:
+0 g & p & f
+ACS:
+A Tom 0

--- a/example/Example4b/lib.adl3
+++ b/example/Example4b/lib.adl3
@@ -1,0 +1,2 @@
+A causes f if g by Tom
+A causes ~f if p by Tom

--- a/example/Example4b/queries.txt
+++ b/example/Example4b/queries.txt
@@ -1,0 +1,4 @@
+possibly involved Tom
+necessary involved Tom
+possibly A at 0
+necessary A at 0

--- a/example/Example4b/scenario.txt
+++ b/example/Example4b/scenario.txt
@@ -1,0 +1,4 @@
+OBS:
+0 g & ~p & ~f
+ACS:
+A Tom 0

--- a/example/lib.adl3
+++ b/example/lib.adl3
@@ -2,4 +2,4 @@ load causes loaded by hunter
 shoot causes ~loaded by hunter
 shoot causes ~alive if loaded & ~hidden by hunter
 escape releases hidden by turkey
-loaded triggers escape
+loaded triggers escape by turkey

--- a/example/lib.adl3
+++ b/example/lib.adl3
@@ -1,5 +1,5 @@
-Load releases loaded during 2
-Load releases ~hidden during 1
-Shoot causes ~loaded during 1
-Shoot causes ~alive if loaded & ~hidden during 1
-impossible Shoot if ~loaded
+load causes loaded by hunter
+shoot causes ~loaded by hunter
+shoot causes ~alive if loaded & ~hidden by hunter
+escape releases hidden by turkey
+loaded triggers escape

--- a/example/queries.txt
+++ b/example/queries.txt
@@ -1,13 +1,6 @@
-necessary executable Load,Shoot in 3
-necessary executable Load,Shoot in 2
-possibly executable shoot in 0
-possibly executable shoot in 1
-necessary executable shoot in 1
-possibly executable shoot in 2
-some random sentence that wont match regex
-necessary alive & ~loaded at 0 when scenario.txt
-necessary alive & ~loaded at -1 when scenario.txt
-possibly hidden at 2 when scenario.txt
-necessary ~hidden at 3 when scenario.txt
-possibly ~loaded & ~alive at 4 when scenario.txt
-necessary ~loaded & ~alive at 4 when scenario.txt
+possibly involved hunter
+necessary involved turkey
+necessary alive at 4
+possibly alive at 4
+necessary escape at 2
+possibly escape at 2

--- a/example/queries.txt
+++ b/example/queries.txt
@@ -1,6 +1,6 @@
 possibly involved hunter
 necessary involved turkey
-necessary alive at 4
-possibly alive at 4
+necessary alive at 4 when ExampleScenario
+possibly alive at 4 when ExampleScenario
 necessary escape at 2
 possibly escape at 2

--- a/example/queries.txt
+++ b/example/queries.txt
@@ -1,6 +1,7 @@
 possibly involved hunter
+possibly involved turkey
 necessary involved turkey
 necessary alive at 4 when ExampleScenario
 possibly alive at 4 when ExampleScenario
-necessary escape at 2
-possibly escape at 2
+necessary escape at 2 when ExampleScenario
+possibly escape at 2 when ExampleScenario

--- a/example/scenario.txt
+++ b/example/scenario.txt
@@ -1,6 +1,5 @@
 OBS:
-0 alive & ~loaded & hidden
-2 alive & ~loaded & ~hidden
+0 alive & ~loaded & ~hidden
 ACS:
-Load 1 2
-Shoot 3 1
+load hunter 1
+shoot hunter 3

--- a/main.py
+++ b/main.py
@@ -25,24 +25,24 @@ def main(library_file: str, scenario_file: str, query_file: str = None):
     print('Parsed queries:')
     for statement in queries:
         print(statement)
-    # engine = Engine()
-    #
-    # if len(queries) == 0:
-    #     print("The library and the scenario are valid.")
-    #
-    # if engine.run(scenario=scenario, domain_desc=domain_desc):
-    #     print('After the engine ran We found', len(engine.models), 'models')
-    #     i = 0
-    #     for model in engine.models:
-    #         print('Final model:', i, '\n', model)
-    #         print('Action history for model', i, 'is:', model.action_history)
-    #         i += 1
-    #     if len(engine.models) != 0:
-    #         for query in queries:
-    #             print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
-    #     else:
-    #         for query in queries:
-    #             print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
+    engine = Engine()
+
+    if len(queries) == 0:
+        print("The library and the scenario are valid.")
+
+    if engine.run(scenario=scenario, domain_desc=domain_desc):
+        print('After the engine ran We found', len(engine.models), 'models')
+        i = 0
+        for model in engine.models:
+            print('Final model:', i, '\n', model)
+            print('Action history for model', i, 'is:', model.action_history)
+            i += 1
+        if len(engine.models) != 0:
+            for query in queries:
+                print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
+        else:
+            for query in queries:
+                print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -47,11 +47,11 @@ def main(library_file: str, scenario_file: str, query_file: str = None):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-l', '--library-file', nargs='?', type=str, default='example/lib.adl3',
+    parser.add_argument('-l', '--library-file', nargs='?', type=str, default='example/Example4b/lib.adl3',
                         const='example/lib.adl3', help='Path to input ADL3 domain description file')
-    parser.add_argument('-s', '--scenario-file', nargs='?', type=str, default='example/scenario.txt',
+    parser.add_argument('-s', '--scenario-file', nargs='?', type=str, default='example/Example4b/scenario.txt',
                         const='example/scenario.txt', help='Path to input ADL3 scenario file')
-    parser.add_argument('-q', '--query-file', nargs='?', type=str, default='example/queries.txt', help='Query file to be parsed')
+    parser.add_argument('-q', '--query-file', nargs='?', type=str, default='example/Example4b/queries.txt', help='Query file to be parsed')
     args = vars(parser.parse_args())
 
     main(**args)

--- a/main.py
+++ b/main.py
@@ -15,8 +15,16 @@ def main(library_file: str, scenario_file: str, query_file: str = None):
     print('Parsed domain description:')
     for statement in domain_desc.statements:
         print(statement)
-    # scenario = parsing.scenario.parse_file(scenario_file)
-    # queries = parsing.query.parse_file(query_file)
+    scenario = parsing.scenario.parse_file(scenario_file)
+    print('Parsed scenario:')
+    for statement in scenario.observations:
+        print(statement)
+    for statement in scenario.action_occurrences:
+        print(statement)
+    queries = parsing.query.parse_file(query_file)
+    print('Parsed queries:')
+    for statement in queries:
+        print(statement)
     # engine = Engine()
     #
     # if len(queries) == 0:

--- a/main.py
+++ b/main.py
@@ -11,27 +11,30 @@ import parsing.query
 
 
 def main(library_file: str, scenario_file: str, query_file: str = None):
-    scenario = parsing.scenario.parse_file(scenario_file)
     domain_desc = parsing.domain_description.parse_file(library_file)
-    queries = parsing.query.parse_file(query_file)
-    engine = Engine()
-
-    if len(queries) == 0:
-        print("The library and the scenario are valid.")
-
-    if engine.run(scenario=scenario, domain_desc=domain_desc):
-        print('After the engine ran We found', len(engine.models), 'models')
-        i = 0
-        for model in engine.models:
-            print('Final model:', i, '\n', model)
-            print('Action history for model', i, 'is:', model.action_history)
-            i += 1
-        if len(engine.models) != 0:
-            for query in queries:
-                print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
-        else:
-            for query in queries:
-                print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
+    print('Parsed domain description:')
+    for statement in domain_desc.statements:
+        print(statement)
+    # scenario = parsing.scenario.parse_file(scenario_file)
+    # queries = parsing.query.parse_file(query_file)
+    # engine = Engine()
+    #
+    # if len(queries) == 0:
+    #     print("The library and the scenario are valid.")
+    #
+    # if engine.run(scenario=scenario, domain_desc=domain_desc):
+    #     print('After the engine ran We found', len(engine.models), 'models')
+    #     i = 0
+    #     for model in engine.models:
+    #         print('Final model:', i, '\n', model)
+    #         print('Action history for model', i, 'is:', model.action_history)
+    #         i += 1
+    #     if len(engine.models) != 0:
+    #         for query in queries:
+    #             print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
+    #     else:
+    #         for query in queries:
+    #             print('Query:', query, 'was evaluated to:', query.validate(engine.models, scenario))
 
 
 if __name__ == '__main__':

--- a/parsing/action_occurrence.py
+++ b/parsing/action_occurrence.py
@@ -8,7 +8,5 @@ def parse_all(lines: List[str]) -> List[ActionOccurrence]:
 
 
 def parse(line: str) -> ActionOccurrence:
-    name, raw_begin_time, raw_duration = line.split(" ")
-    begin_time = int(raw_begin_time)
-    duration = int(raw_duration)
-    return ActionOccurrence(name, begin_time, duration)
+    name, agent_name, raw_begin_time = line.split(" ")
+    return ActionOccurrence(name=name, begin_time=int(raw_begin_time), duration=1, agent=agent_name)

--- a/parsing/condition.py
+++ b/parsing/condition.py
@@ -4,4 +4,6 @@ from structs.condition import Condition
 
 
 def parse(input: str) -> Condition:
+    if input is None:
+        return None
     return Condition(sympy_parser.parse_expr(input))

--- a/parsing/condition.py
+++ b/parsing/condition.py
@@ -1,9 +1,9 @@
 import sympy.parsing.sympy_parser as sympy_parser
-
+from typing import Union
 from structs.condition import Condition
 
 
-def parse(input: str) -> Condition:
+def parse(input: str) -> Union[Condition, bool]:
     if input is None:
-        return None
+        return True
     return Condition(sympy_parser.parse_expr(input))

--- a/parsing/query.py
+++ b/parsing/query.py
@@ -1,5 +1,5 @@
 from typing import List, Union
-from structs.query import Query, ActionQuery, ScenarioQuery
+from structs.query import Query, ActionQuery, ConditionQuery, InvolvedQuery
 import re
 
 
@@ -20,14 +20,18 @@ def parse_text(text: str) -> List[Query]:
 
 
 def parse_query(raw_query: str) -> Union[Query, None]:
-    action_regex = re.compile("(necessary|possibly) executable (.*?) in ([1-9]+)$")
-    scenario_regex = re.compile("(necessary|possibly) (.*?) at ([0-9]+) when ([a-zA-Z0-9].*[a-zA-Z0-9]+)$")
+    action_regex = re.compile("(necessary|possibly) (.*?) at ([0-9]+)$")
+    # We need "when Sc" in order to distinguish ActionQuery from ConditionQuery?
+    condition_regex = re.compile("(necessary|possibly) (.*?) at ([0-9]+) when ([a-zA-Z0-9].*[a-zA-Z0-9]+)$")
+    involved_regex = re.compile("(necessary|possibly) involved (.*?)$")
     action_match = action_regex.search(raw_query)
+    condition_match = condition_regex.search(raw_query)
+    involved_match = involved_regex.search(raw_query)
     if action_match:
         # print("Query:", raw_query, "matched action_regex, groups:", action_match.groups())
         return ActionQuery(*action_match.groups())
-    else:
-        scenario_match = scenario_regex.search(raw_query)
-        if scenario_match:
-            return ScenarioQuery(*scenario_match.groups())
+    elif condition_match:
+        return ConditionQuery(*condition_match.groups())
+    elif involved_match:
+        return InvolvedQuery(*involved_match.groups())
     return None

--- a/parsing/statement.py
+++ b/parsing/statement.py
@@ -18,7 +18,8 @@ def parse(input: str) -> Statement:
         EffectStatementParser,
         ImpossibleIfParser,
         ImpossibleByParser,
-        TriggersParser
+        TriggersParser,
+        TriggersAgentParser
     ]
 
     for t in types:
@@ -107,4 +108,11 @@ class TriggersParser:
 
     @staticmethod
     def parse_groups(raw_condition, raw_action):
-        return Triggers(condition=parsing.condition.parse(raw_condition), action=raw_action)
+        return Triggers(condition=parsing.condition.parse(raw_condition), action=raw_action, agent='nobody')
+
+class TriggersAgentParser:
+    regex = re.compile("^([^ ]*) triggers ([^ ]*) by ([^ ]*)$")
+
+    @staticmethod
+    def parse_groups(raw_condition, raw_action, agent):
+        return Triggers(condition=parsing.condition.parse(raw_condition), action=raw_action, agent=agent)

--- a/parsing/statement.py
+++ b/parsing/statement.py
@@ -14,6 +14,7 @@ import parsing.condition
 
 def parse(input: str) -> Statement:
     types = [
+        EffectStatementAgentParser,
         EffectStatementParser,
         ImpossibleIfParser,
         ImpossibleByParser,
@@ -26,14 +27,21 @@ def parse(input: str) -> Statement:
             return t.parse_groups(*match.groups())
 
 
-class EffectStatementParser:
+def parse_statement_type(raw_statement_type: str) -> type:
+    if raw_statement_type == "causes":
+        return Causes
+    elif raw_statement_type == "releases":
+        return Releases
+
+
+class EffectStatementAgentParser:
     regex = re.compile("^([^ ]*) (causes|releases) (.*?)( if (.*))? by ([^ ]*)$")
 
     @staticmethod
     def parse_groups(raw_action, raw_statement_type,
                      raw_effect, if_clause, raw_condition, agent):
-        statement_type = EffectStatementParser.parse_statement_type(raw_statement_type)
-        # condition_args = EffectStatementParser.parse_optional_condition_args(raw_condition)
+        statement_type = parse_statement_type(raw_statement_type)
+        # condition_args = EffectStatementAgentParser.parse_optional_condition_args(raw_condition)
 
         return statement_type(
             action=raw_action,
@@ -41,13 +49,6 @@ class EffectStatementParser:
             condition=parsing.condition.parse(raw_condition),
             agent=agent,
             )
-
-    @staticmethod
-    def parse_statement_type(raw_statement_type: str) -> type:
-        if raw_statement_type == "causes":
-            return Causes
-        elif raw_statement_type == "releases":
-            return Releases
 
     # @staticmethod
     # def parse_optional_condition_args(raw_condition: str) -> dict:
@@ -57,6 +58,23 @@ class EffectStatementParser:
     #     # but we just parse it as a formula anyway.
     #     condition = parsing.condition.parse(raw_condition)
     #     return {"condition": condition}
+
+
+class EffectStatementParser:
+    regex = re.compile("^([^ ]*) (causes|releases) (.*?)( if (.*))?$")
+
+    @staticmethod
+    def parse_groups(raw_action, raw_statement_type,
+                     raw_effect, if_clause, raw_condition):
+        statement_type = parse_statement_type(raw_statement_type)
+        # condition_args = EffectStatementAgentParser.parse_optional_condition_args(raw_condition)
+
+        return statement_type(
+            action=raw_action,
+            effect=parsing.condition.parse(raw_effect),
+            condition=parsing.condition.parse(raw_condition),
+            agent='nobody',
+            )
 
 
 class ImpossibleIfParser:

--- a/parsing/statement.py
+++ b/parsing/statement.py
@@ -5,7 +5,9 @@ from structs.statements import (
     Causes,
     Releases,
     ImpossibleIf,
-    ImpossibleAt
+    ImpossibleAt,
+    ImpossibleBy,
+    Triggers
 )
 import parsing.condition
 
@@ -14,7 +16,8 @@ def parse(input: str) -> Statement:
     types = [
         EffectStatementParser,
         ImpossibleIfParser,
-        ImpossibleAtParser,
+        ImpossibleByParser,
+        TriggersParser
     ]
 
     for t in types:
@@ -24,19 +27,20 @@ def parse(input: str) -> Statement:
 
 
 class EffectStatementParser:
-    regex = re.compile("^([^ ]*) (causes|releases) (.*?)( if (.*))? during ([0-9]+)$")
+    regex = re.compile("^([^ ]*) (causes|releases) (.*?)( if (.*))? by ([^ ]*)$")
 
     @staticmethod
     def parse_groups(raw_action, raw_statement_type,
-                     raw_effect, if_clause, raw_condition, raw_duration):
+                     raw_effect, if_clause, raw_condition, agent):
         statement_type = EffectStatementParser.parse_statement_type(raw_statement_type)
-        condition_args = EffectStatementParser.parse_optional_condition_args(raw_condition)
+        # condition_args = EffectStatementParser.parse_optional_condition_args(raw_condition)
 
         return statement_type(
             action=raw_action,
             effect=parsing.condition.parse(raw_effect),
-            duration=int(raw_duration),
-            **condition_args)
+            condition=parsing.condition.parse(raw_condition),
+            agent=agent,
+            )
 
     @staticmethod
     def parse_statement_type(raw_statement_type: str) -> type:
@@ -45,14 +49,14 @@ class EffectStatementParser:
         elif raw_statement_type == "releases":
             return Releases
 
-    @staticmethod
-    def parse_optional_condition_args(raw_condition: str) -> dict:
-        if raw_condition is None:
-            return {}
-        # Releases should have a single fluent,
-        # but we just parse it as a formula anyway.
-        condition = parsing.condition.parse(raw_condition)
-        return {"condition": condition}
+    # @staticmethod
+    # def parse_optional_condition_args(raw_condition: str) -> dict:
+    #     if raw_condition is None:
+    #         return {}
+    #     # Releases should have a single fluent,
+    #     # but we just parse it as a formula anyway.
+    #     condition = parsing.condition.parse(raw_condition)
+    #     return {"condition": condition}
 
 
 class ImpossibleIfParser:
@@ -63,9 +67,26 @@ class ImpossibleIfParser:
         return ImpossibleIf(raw_action, parsing.condition.parse(raw_condition))
 
 
+# TODO remove
 class ImpossibleAtParser:
     regex = re.compile("^impossible ([^ ]*) at ([0-9]+)$")
 
     @staticmethod
     def parse_groups(raw_action, raw_time):
         return ImpossibleAt(raw_action, int(raw_time))
+
+
+class ImpossibleByParser:
+    regex = re.compile("^impossible ([^ ]*) by ([^ ]*)$")
+
+    @staticmethod
+    def parse_groups(raw_action, agent):
+        return ImpossibleBy(action=raw_action, agent=agent)
+
+
+class TriggersParser:
+    regex = re.compile("^([^ ]*) triggers ([^ ]*)$")
+
+    @staticmethod
+    def parse_groups(raw_condition, raw_action):
+        return Triggers(condition=parsing.condition.parse(raw_condition), action=raw_action)

--- a/parsing/test_domain_description.py
+++ b/parsing/test_domain_description.py
@@ -1,31 +1,38 @@
 import unittest
 import sympy
 import parsing.domain_description
-from structs.statements import Causes, Releases, ImpossibleIf, ImpossibleAt
+import os
+from structs.statements import Causes, Releases, Triggers
 from structs.condition import Condition
 
 
 class DomainDescriptionParsingTestCase(unittest.TestCase):
     def test_parse_example(self):
-        description = parsing.domain_description.parse_file("example/lib.adl3")
+        os.chdir(os.path.dirname(os.path.abspath(__file__)))
+        description = parsing.domain_description.parse_file("../example/lib.adl3")
 
         self.assertEqual(len(description.statements), 5)
 
         alive, loaded, hidden = sympy.symbols("alive,loaded,hidden")
-        self.assertTrue(isinstance(description.statements[0], Releases))
-        self.assertEqual(description.statements[0], Releases(
-            action="Load", effect=Condition(loaded), duration=2))
-        self.assertTrue(isinstance(description.statements[1], Releases))
-        self.assertEqual(description.statements[1], Releases(
-            action="Load", effect=Condition(~hidden), duration=1))
+        #####
+        self.assertTrue(isinstance(description.statements[0], Causes))
+        self.assertEqual(Causes(
+            action="load", effect=Condition(loaded), agent="hunter"), description.statements[0])
+        #####
+        self.assertTrue(isinstance(description.statements[1], Causes))
+        self.assertEqual(Causes(
+            action="shoot", effect=Condition(~loaded), agent="hunter"), description.statements[1])
+        #####
         self.assertTrue(isinstance(description.statements[2], Causes))
-        self.assertEqual(description.statements[2], Causes(
-            action="Shoot", effect=Condition(~loaded), duration=1))
-        self.assertTrue(isinstance(description.statements[3], Causes))
-        self.assertEqual(description.statements[3], Causes(
-            action="Shoot",
-            effect=Condition(~alive), condition=Condition(~hidden & loaded),
-            duration=1))
-        self.assertTrue(isinstance(description.statements[4], ImpossibleIf))
-        self.assertEqual(description.statements[4], ImpossibleIf(
-            action="Shoot", condition=Condition(~loaded)))
+        self.assertEqual(Causes(
+            action="shoot", effect=Condition(~alive), condition=Condition(loaded & ~hidden), agent="hunter"),
+            description.statements[2])
+        #####
+        self.assertTrue(isinstance(description.statements[3], Releases))
+        self.assertEqual(Releases(
+            action="escape",
+            effect=Condition(hidden), agent="turkey"), description.statements[3])
+        #####
+        self.assertTrue(isinstance(description.statements[4], Triggers))
+        self.assertEqual(Triggers(
+            action="escape", condition=Condition(loaded)), description.statements[4])

--- a/parsing/test_query.py
+++ b/parsing/test_query.py
@@ -1,55 +1,51 @@
 import unittest
 import sympy
+import os
 import parsing.query
 import structs.query
-import structs.query
-from structs.statements import Causes, Releases, ImpossibleIf
-from structs.condition import Condition
+from structs.query import *
+
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 
 class QueryTestCase(unittest.TestCase):
     def test_parse_example(self):
-        queries = parsing.query.parse_file("example/queries.txt")
+        queries = parsing.query.parse_file("../example/queries.txt")
         # self.assertEqual(len(queries), 6)
-        assert len(queries) == 8
+        self.assertEqual(6, len(queries))
 
-        # necessary executable load,shoot in 3 (ActionQuery)
-        self.assertEqual(queries[0].query_type, structs.query.QueryType.NECESSARY)
-        self.assertEqual(queries[0].actions, ["load", "shoot"])
-        self.assertEqual(queries[0].duration, 3)
+        # possibly involved hunter
+        self.assertEqual(True, isinstance(queries[0], InvolvedQuery))
+        self.assertEqual(structs.query.QueryType.POSSIBLY, queries[0].query_type)
+        self.assertEqual(queries[0].agent, "hunter")
 
-        # possibly executable shoot in 1 (ActionQuery)
-        self.assertEqual(queries[1].query_type, structs.query.QueryType.POSSIBLY)
-        self.assertEqual(queries[1].actions, ["shoot"])
-        self.assertEqual(queries[1].duration, 1)
-
-        # possibly executable shoot in 2 (ActionQuery)
-        self.assertEqual(queries[2].query_type, structs.query.QueryType.POSSIBLY)
-        self.assertEqual(queries[2].actions, ["shoot"])
-        self.assertEqual(queries[2].duration, 2)
+        # necessary involved turkey
+        self.assertEqual(True, isinstance(queries[1], InvolvedQuery))
+        self.assertEqual(structs.query.QueryType.NECESSARY, queries[1].query_type)
+        self.assertEqual(queries[1].agent, "turkey")
 
         alive, loaded, hidden = sympy.symbols("alive, loaded, hidden")
-        # necessary alive & ~loaded at 0 when scenario.txt (ScenarioQuery)
-        self.assertEqual(queries[3].query_type, structs.query.QueryType.NECESSARY)
-        self.assertEqual(queries[3].condition.formula, alive & ~loaded)
-        self.assertEqual(queries[3].time_point, 0)
+        # possibly executable shoot in 2 (ActionQuery)
+        self.assertEqual(True, isinstance(queries[2], ConditionQuery))
+        self.assertEqual(structs.query.QueryType.NECESSARY, queries[2].query_type)
+        self.assertEqual(alive, queries[2].condition.formula)
+        self.assertEqual(4, queries[2].time_point)
 
-        # possibly hidden at 2 when scenario.txt (ScenarioQuery)
-        self.assertEqual(queries[4].query_type, structs.query.QueryType.POSSIBLY)
-        self.assertEqual(queries[4].condition.formula, hidden)
-        self.assertEqual(queries[4].time_point, 2)
+        # necessary alive & ~loaded at 0 when scenario.txt (ConditionQuery)
+        self.assertEqual(True, isinstance(queries[3], ConditionQuery))
+        self.assertEqual(structs.query.QueryType.POSSIBLY, queries[3].query_type)
+        self.assertEqual(alive, queries[3].condition.formula)
+        self.assertEqual(4, queries[3].time_point)
 
-        # necessary ~hidden at 3 when scenario.txt (ScenarioQuery)
-        self.assertEqual(queries[5].query_type, structs.query.QueryType.NECESSARY)
-        self.assertEqual(queries[5].condition.formula, ~hidden)
-        self.assertEqual(queries[5].time_point, 3)
+        # possibly hidden at 2 when scenario.txt (ConditionQuery)
+        self.assertEqual(True, isinstance(queries[4], ActionQuery))
+        self.assertEqual(structs.query.QueryType.NECESSARY, queries[4].query_type)
+        self.assertEqual(["escape"], queries[4].action_strings)
+        self.assertEqual(2, int(queries[4].time_point))
 
-        # possibly ~loaded & ~alive at 4 when scenario.txt (ScenarioQuery)
-        self.assertEqual(queries[6].query_type, structs.query.QueryType.POSSIBLY)
-        self.assertEqual(queries[6].condition.formula, ~loaded & ~alive)
-        self.assertEqual(queries[6].time_point, 4)
-
-        # necessary ~loaded & ~alive at 4 when scenario.txt (ScenarioQuery)
-        self.assertEqual(queries[7].query_type, structs.query.QueryType.NECESSARY)
-        self.assertEqual(queries[7].condition.formula, ~loaded & ~alive)
-        self.assertEqual(queries[7].time_point, 4)
+        # necessary ~hidden at 3 when scenario.txt (ConditionQuery)
+        self.assertEqual(True, isinstance(queries[5], ActionQuery))
+        self.assertEqual(structs.query.QueryType.POSSIBLY, queries[5].query_type)
+        self.assertEqual(["escape"], queries[5].action_strings)
+        self.assertEqual(2, int(queries[5].time_point))

--- a/parsing/test_scenario.py
+++ b/parsing/test_scenario.py
@@ -1,29 +1,24 @@
 import unittest
 import sympy
-
+import os
 import parsing.scenario
 import parsing.condition
 from structs.observation import Observation
 from structs.action_occurrence import ActionOccurrence
 from structs.condition import Condition
 
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
 
 class ScenarioParserTestCase(unittest.TestCase):
     def test_test(self):
-        scenario = parsing.scenario.parse_file("example/scenario.txt")
+        scenario = parsing.scenario.parse_file("../example/scenario.txt")
 
-        self.assertEqual(len(scenario.observations), 2)
+        self.assertEqual(len(scenario.observations), 1)
 
         alive, loaded, hidden = sympy.symbols("alive,loaded,hidden")
-        self.assertEqual(scenario.observations[0], Observation(
-            begin_time=0,
-            condition=Condition(alive & ~loaded & hidden)))
-        self.assertEqual(scenario.observations[1], Observation(
-            begin_time=2,
-            condition=Condition(alive & ~loaded & ~hidden)))
+        self.assertEqual(Observation(begin_time=0, condition=Condition(alive & ~loaded & ~hidden)), scenario.observations[0])
 
-        self.assertEqual(len(scenario.action_occurrences), 2)
-        self.assertEqual(scenario.action_occurrences[0],
-                         ActionOccurrence(name="Load", begin_time=1, duration=2))
-        self.assertEqual(scenario.action_occurrences[1],
-                         ActionOccurrence(name="Shoot", begin_time=3, duration=1))
+        self.assertEqual(2, len(scenario.action_occurrences))
+        self.assertEqual(ActionOccurrence(name="load", begin_time=1, agent="hunter"), scenario.action_occurrences[0])
+        self.assertEqual(ActionOccurrence(name="shoot", begin_time=3, agent="hunter"), scenario.action_occurrences[1])

--- a/parsing/test_statement.py
+++ b/parsing/test_statement.py
@@ -5,16 +5,14 @@ import parsing.statement
 from structs.statements import (
     Causes,
     Releases,
-    ImpossibleAt,
-    ImpossibleIf
+    ImpossibleIf,
+    ImpossibleBy,
+    Triggers
 )
 from structs.condition import Condition
 
 
 class StatementParsingTestCase(unittest.TestCase):
-    # def test_impossible_at(self):
-    #     statement = parsing.statement.parse("impossible Work at 14")
-    #     self.assertEqual(statement, ImpossibleAt(action="Work", time=14))
 
     def test_impossible_if(self):
         statement = parsing.statement.parse("impossible Work if sick | dead")
@@ -38,13 +36,24 @@ class StatementParsingTestCase(unittest.TestCase):
         statement = parsing.statement.parse("Use releases broken by lol")
         broken = sympy.symbols("broken")
         self.assertEqual(Releases(
-                 action="Use",
-                 effect=Condition(broken), agent="lol"), statement)
+            action="Use",
+            effect=Condition(broken), agent="lol"), statement)
 
     def test_conditional_releases(self):
         statement = parsing.statement.parse("Use releases broken if unlucky by lol")
         broken, unlucky = sympy.symbols("broken,unlucky")
         self.assertEqual(Releases(
-                 action="Use",
-                 effect=Condition(broken),
-                 condition=Condition(unlucky), agent="lol"), statement)
+            action="Use",
+            effect=Condition(broken),
+            condition=Condition(unlucky), agent="lol"), statement)
+
+    def test_impossible_by(self):
+        statement = parsing.statement.parse("impossible work by Kuba")
+        self.assertEqual(ImpossibleBy(
+            action="work", agent="Kuba"), statement)
+
+    def test_triggers(self):
+        statement = parsing.statement.parse("detonate triggers explosion")
+        detonate = sympy.symbols("detonate")
+        self.assertEqual(Triggers(
+            action="explosion", condition=Condition(detonate)), statement)

--- a/parsing/test_statement.py
+++ b/parsing/test_statement.py
@@ -12,47 +12,39 @@ from structs.condition import Condition
 
 
 class StatementParsingTestCase(unittest.TestCase):
-    def test_impossible_at(self):
-        statement = parsing.statement.parse("impossible Work at 14")
-        self.assertEqual(statement, ImpossibleAt(action="Work", time=14))
+    # def test_impossible_at(self):
+    #     statement = parsing.statement.parse("impossible Work at 14")
+    #     self.assertEqual(statement, ImpossibleAt(action="Work", time=14))
 
     def test_impossible_if(self):
         statement = parsing.statement.parse("impossible Work if sick | dead")
         expected_condition = parsing.condition.parse("sick | dead")
-        self.assertEqual(statement,
-            ImpossibleIf(action="Work", condition=expected_condition))
+        self.assertEqual(ImpossibleIf(action="Work", condition=expected_condition), statement)
 
     def test_unconditional_causes(self):
-        statement = parsing.statement.parse("Charge causes charged during 6")
+        statement = parsing.statement.parse("Charge causes charged by Kuba")
         charged = sympy.symbols("charged")
-        self.assertEqual(statement,
-            Causes(action="Charge", effect=Condition(charged), duration=6))
+        self.assertEqual(Causes(action="Charge", effect=Condition(charged), agent="Kuba"), statement)
 
     def test_conditional_causes(self):
-        statement = parsing.statement.parse("Charge causes charged if plugged_in during 6")
+        statement = parsing.statement.parse("Charge causes charged if plugged_in by Teddy")
         charged, plugged_in = sympy.symbols("charged,plugged_in")
-        self.assertEqual(statement,
-            Causes(
-                action="Charge",
-                effect=Condition(charged),
-                condition=Condition(plugged_in),
-                duration=6))
+        self.assertEqual(Causes(
+            action="Charge",
+            effect=Condition(charged),
+            condition=Condition(plugged_in), agent="Teddy"), statement)
 
     def test_unconditional_releases(self):
-        statement = parsing.statement.parse("Use releases broken during 14")
+        statement = parsing.statement.parse("Use releases broken by lol")
         broken = sympy.symbols("broken")
-        self.assertEqual(statement,
-             Releases(
+        self.assertEqual(Releases(
                  action="Use",
-                 effect=Condition(broken),
-                 duration=14))
+                 effect=Condition(broken), agent="lol"), statement)
 
     def test_conditional_releases(self):
-        statement = parsing.statement.parse("Use releases broken if unlucky during 14")
+        statement = parsing.statement.parse("Use releases broken if unlucky by lol")
         broken, unlucky = sympy.symbols("broken,unlucky")
-        self.assertEqual(statement,
-             Releases(
+        self.assertEqual(Releases(
                  action="Use",
                  effect=Condition(broken),
-                 condition=Condition(unlucky),
-                 duration=14))
+                 condition=Condition(unlucky), agent="lol"), statement)

--- a/structs/action_occurrence.py
+++ b/structs/action_occurrence.py
@@ -4,4 +4,5 @@ from typing import NamedTuple
 class ActionOccurrence(NamedTuple):
     name: str
     begin_time: int
-    duration: int
+    agent: str
+    duration: int = 1  # Keep for compatibility reasons?

--- a/structs/condition.py
+++ b/structs/condition.py
@@ -3,4 +3,4 @@ from sympy.logic import boolalg
 
 
 class Condition(NamedTuple):
-    formula: boolalg.Boolean
+    formula: boolalg.Boolean = True

--- a/structs/query.py
+++ b/structs/query.py
@@ -152,8 +152,22 @@ class InvolvedQuery(Query):
         self.str = "{} involved {} ".format(self.query_type, self.agent)
 
     def validate(self,  models: List[Model], scen: Scenario = None) -> bool:
-        # TODO
-        return False
+        if len(models) == 0:
+            # If no models then agent surely was not involved?
+            return True
+
+        for model in models:
+            agent_involved_in_model = False
+            for action in model.action_history.values():
+                if action.agent == self.agent and self.query_type == QueryType.POSSIBLY:
+                    return True
+                elif action.agent == self.agent:
+                    agent_involved_in_model = True
+                    break
+            if not agent_involved_in_model and self.query_type == QueryType.NECESSARY:
+                return False
+
+        return True
 
     def __str__(self):
         return self.str

--- a/structs/query.py
+++ b/structs/query.py
@@ -46,7 +46,7 @@ class ActionQuery(Query):
                     if act_str not in model_action_strings:
                         break
                 # TODO simplify logic
-                t = self.time_point
+                t = int(self.time_point)
                 for i in range(len(self.action_strings)):
                     if t in model.action_history.keys() and model.action_history[t].name.lower() == self.action_strings[i]:
                         # found first action
@@ -80,7 +80,7 @@ class ActionQuery(Query):
                     if act_str not in model_action_strings:
                         return False
                 # TODO simplify logic
-                t = self.time_point
+                t = int(self.time_point)
                 for i in range(len(self.action_strings)):
                     if t in model.action_history.keys() and model.action_history[t].name.lower() == self.action_strings[i]:
                         # found first action
@@ -105,7 +105,7 @@ class ActionQuery(Query):
                                             # valid interval found
                                             is_valid = True
                             t += 1
-                t += 1
+                #t += 1
 
         return is_valid
 

--- a/structs/query.py
+++ b/structs/query.py
@@ -31,11 +31,11 @@ class ActionQuery(Query):
         if len(models) == 0:
             return True
 
-        scenario_act_names = [act.name.lower() for act in scen.action_occurrences]
-        for action_str in self.action_strings:
-            if action_str not in scenario_act_names:
-                print("Action:", action_str, " is not in the scenario!")
-                return False
+        #scenario_act_names = [act.name.lower() for act in scen.action_occurrences]
+        #for action_str in self.action_strings:
+        #    if action_str not in scenario_act_names:
+        #        print("Action:", action_str, " is not in the scenario!")
+        #        return False
         # print('self.action_strings:', self.action_strings)
         is_valid = False
         if self.query_type == QueryType.POSSIBLY:

--- a/structs/statements.py
+++ b/structs/statements.py
@@ -11,7 +11,7 @@ class EffectStatement(Statement, NamedTuple):
     action: str
     effect: Condition
     duration: int = 1
-    condition: Condition = None
+    condition: Condition = True
     agent: str = 'nobody'
 
 

--- a/structs/statements.py
+++ b/structs/statements.py
@@ -10,8 +10,9 @@ class Statement:
 class EffectStatement(Statement, NamedTuple):
     action: str
     effect: Condition
-    duration: int
-    condition: Condition = True
+    duration: int = 1
+    condition: Condition = None
+    agent: str = 'nobody'
 
 
 class Causes(EffectStatement):
@@ -27,6 +28,17 @@ class ImpossibleIf(Statement, NamedTuple):
     condition: Condition
 
 
+# TODO REMOVE
 class ImpossibleAt(Statement, NamedTuple):
     action: str
     time: int
+
+
+class ImpossibleBy(Statement, NamedTuple):
+    action: str
+    agent: str
+
+
+class Triggers(Statement, NamedTuple):
+    condition: Condition
+    action: str

--- a/structs/statements.py
+++ b/structs/statements.py
@@ -42,3 +42,4 @@ class ImpossibleBy(Statement, NamedTuple):
 class Triggers(Statement, NamedTuple):
     condition: Condition
     action: str
+    agent: str

--- a/ui/gui.py
+++ b/ui/gui.py
@@ -1,5 +1,4 @@
 import tkinter as tk
-import sys
 import parsing.scenario, parsing.domain_description, parsing.query
 from engine.engine import Engine
 


### PR DESCRIPTION
In order to fix the problem of creation models in the Example 3a and 3b, this pull request was created.
Basically, those commits in PR create an initial condition from combination of all fluents in domain description and from initial observation at timepoint 0. Later the models are created from the initial condition and satisfiability of it.
There is still a problem with execution of actions in those examples. They are simply not executed and the queries are giving a very odd results. From brief investigation it seems that the problem is in self.checker.validate_model function, since in every timepiint it returns an action = None.